### PR TITLE
Fix `.panel-tabset` in pkgdown vignette

### DIFF
--- a/vignettes/report-monthly-outcomes.qmd
+++ b/vignettes/report-monthly-outcomes.qmd
@@ -283,10 +283,9 @@ selectedOrgDisplay = {
 }
 ```
 
-::: {.panel-tabset}
+### Treatment outcome measures
 
-
-### Reliable improvement (M186)
+#### Reliable improvement (M186)
 
 ```{ojs}
 //| label: time-series-plot-m186
@@ -294,7 +293,7 @@ selectedOrgDisplay = {
 plotM186 = createTimeSeriesPlot(plotDataM186, "Reliable improvement (%)", [0, 100])
 ```
 
-### Recovery (M192)
+#### Recovery (M192)
 
 ```{ojs}
 //| label: time-series-plot-m192
@@ -302,15 +301,13 @@ plotM186 = createTimeSeriesPlot(plotDataM186, "Reliable improvement (%)", [0, 10
 plotM192 = createTimeSeriesPlot(plotDataM192, "Recovery (%)", [0, 100])
 ```
 
-### Reliable recovery (M195)
+#### Reliable recovery (M195)
 
 ```{ojs}
 //| label: time-series-plot-m195
 
 plotM195 = createTimeSeriesPlot(plotDataM195, "Reliable recovery (%)", [0, 100])
 ```
-
-:::
 
 ### Measure desriptions
 

--- a/vignettes/report-monthly-tx-appt.qmd
+++ b/vignettes/report-monthly-tx-appt.qmd
@@ -276,9 +276,9 @@ selectedOrgDisplay = {
 }
 ```
 
-::: {.panel-tabset}
+### Treatment appointment measures
 
-### Mean HI appointments (M112)
+#### Mean HI appointments (M112)
 
 ```{ojs}
 //| label: time-series-plot-m112
@@ -286,15 +286,13 @@ selectedOrgDisplay = {
 plotM112 = createTimeSeriesPlot(plotDataM112, "Mean HI appointments")
 ```
 
-### Mean LI appointments (M120)
+#### Mean LI appointments (M120)
 
 ```{ojs}
 //| label: time-series-plot-m120
 
 plotM120 = createTimeSeriesPlot(plotDataM120, "Mean LI appointments")
 ```
-
-:::
 
 ### Measure descriptions
 


### PR DESCRIPTION
This feature is not available, so removing it and using subheadings instead.