### PR TITLE
Fix annual metadata vignette

### DIFF
--- a/man/summarise_percentiles.Rd
+++ b/man/summarise_percentiles.Rd
@@ -15,29 +15,25 @@ summarise_percentiles(
 \arguments{
 \item{df}{Data frame or tibble containing the data to summarise}
 
-\item{period_col}{Column name for the period variable (unquoted), used for
-ordering results. Typically a date column like \code{end_date}}
+\item{period_col}{Column name for the period variable, used for
+ordering results. Typically a date column e.g., \code{end_date}}
 
-\item{value_col}{Column name for the numeric variable to calculate
-percentiles from (unquoted)}
+\item{value_col}{Column name for the numeric variable to calculate percentiles}
 
 \item{percentiles}{Numeric vector of percentiles to calculate, specified as
 proportions between 0 and 1. Default is \code{seq(0.1, 0.9, 0.1)} (10th to 90th
 percentiles by 10s)}
 
-\item{group_by}{Optional grouping variables (unquoted). Can be a single
-column name or a vector of column names using \code{c()}. Default is \code{NULL}
-(no grouping beyond period)}
+\item{group_by}{Optional grouping variables. Can be a single
+column name or a vector of column names using \code{c()}. Default is \code{NULL}.}
 }
 \value{
-A tibble with columns for the period, percentile values, calculated
-values, and any grouping variables. Results are sorted by period
-(descending) and percentile (ascending)
+A tibble with columns for the period, percentile values, calculated values, and any grouping variables.
 }
 \description{
 Summarises a numeric variable by calculating specified percentiles,
-optionally grouped by period and other variables. Useful for creating
-percentile distributions over time or across groups.
+optionally grouped by period and other grouping variables. Useful for creating
+percentile distributions over time or across different measures.
 }
 \examples{
 \dontrun{

--- a/vignettes/metadata-annual.Rmd
+++ b/vignettes/metadata-annual.Rmd
@@ -23,7 +23,7 @@ library(reactable)
 
 # Metadata for annual measures
 metadata_measures_annual <- get_metadata_measures_annual() |>
-  filter(dataset_name == "key_measures") |>
+  filter(dataset_name == "key_measures_annual") |>
   select(field_name, description)
 
 metadata_measures_annual_standard <- metadata_measures_annual |>
@@ -51,7 +51,7 @@ metadata_measures_annual_measures <- metadata_measures_annual |>
 
 # Metadata for annual variables
 metadata_variables_annual <- get_metadata_variables_annual() |>
-  filter(dataset_name == "key_measures") |>
+  filter(dataset_name == "key_measures_annual") |>
   select(
     variable_type,
     variable_type,
@@ -70,17 +70,7 @@ reactable(
   metadata_measures_annual_measures,
   searchable = TRUE,
   sortable = FALSE,
-  searchMethod = JS(
-    "function(rows, columnIds, filterValue) {
-    return rows.filter(function(row) {
-      var field = String(row.values['field_name']).toLowerCase();
-      var desc = String(row.values['description']).toLowerCase();
-      var search = filterValue.toLowerCase();
-      return field.indexOf(search) >= 0 || desc.indexOf(search) >= 0;
-    });
-  }"
-  ),
-  defaultPageSize = nrow(metadata_measures_annual_measures),
+  defaultPageSize = 10,
   columns = list(
     field_name = colDef(
       name = "Column name and description",
@@ -96,7 +86,7 @@ reactable(
         )
       }
     ),
-    description = colDef(show = FALSE)
+    description = colDef(show = FALSE, searchable = TRUE)
   ),
   outlined = TRUE,
   striped = TRUE
@@ -115,7 +105,7 @@ reactable(
   metadata_measures_annual_standard,
   searchable = FALSE,
   sortable = FALSE,
-  defaultPageSize = nrow(metadata_measures_annual_standard),
+  defaultPageSize = 10,
   columns = list(
     field_name = colDef(
       name = "Column name and description",
@@ -131,7 +121,7 @@ reactable(
         )
       }
     ),
-    description = colDef(show = FALSE)
+    description = colDef(show = FALSE, searchable = TRUE)
   ),
   outlined = TRUE,
   striped = TRUE
@@ -156,7 +146,7 @@ reactable(
   metadata_variables_annual,
   searchable = TRUE,
   sortable = FALSE,
-  defaultPageSize = nrow(metadata_variables_annual),
+  defaultPageSize = 10,
   columns = list(
     variable_type = colDef(
       name = "Variable type",

--- a/vignettes/metadata-monthly-core.Rmd
+++ b/vignettes/metadata-monthly-core.Rmd
@@ -35,17 +35,7 @@ reactable(
   metadata_monthly_core,
   searchable = TRUE,
   sortable = FALSE,
-  searchMethod = JS(
-    "function(rows, columnIds, filterValue) {
-    return rows.filter(function(row) {
-      var measure = String(row.values['measure_id']).toLowerCase();
-      var desc = String(row.values['description']).toLowerCase();
-      var search = filterValue.toLowerCase();
-      return measure.indexOf(search) >= 0 || desc.indexOf(search) >= 0;
-    });
-  }"
-  ),
-  defaultPageSize = nrow(metadata_monthly_core),
+  defaultPageSize = 10,
   columns = list(
     measure_id = colDef(
       name = "Measure ID and description",
@@ -61,7 +51,7 @@ reactable(
         )
       }
     ),
-    description = colDef(show = FALSE)
+    description = colDef(show = FALSE, searchable = TRUE)
   ),
   outlined = TRUE,
   striped = TRUE

--- a/vignettes/metadata-monthly-ea.Rmd
+++ b/vignettes/metadata-monthly-ea.Rmd
@@ -35,17 +35,7 @@ reactable(
   metadata_monthly_ea,
   searchable = TRUE,
   sortable = FALSE,
-  searchMethod = JS(
-    "function(rows, columnIds, filterValue) {
-    return rows.filter(function(row) {
-      var measure = String(row.values['measure_id']).toLowerCase();
-      var desc = String(row.values['description']).toLowerCase();
-      var search = filterValue.toLowerCase();
-      return measure.indexOf(search) >= 0 || desc.indexOf(search) >= 0;
-    });
-  }"
-  ),
-  defaultPageSize = nrow(metadata_monthly_ea),
+  defaultPageSize = 10,
   columns = list(
     measure_id = colDef(
       name = "Measure ID and description",
@@ -61,7 +51,7 @@ reactable(
         )
       }
     ),
-    description = colDef(show = FALSE)
+    description = colDef(show = FALSE, searchable = TRUE)
   ),
   outlined = TRUE,
   striped = TRUE

--- a/vignettes/metadata-monthly-ltc.Rmd
+++ b/vignettes/metadata-monthly-ltc.Rmd
@@ -35,17 +35,7 @@ reactable(
   metadata_monthly_ltc,
   searchable = TRUE,
   sortable = FALSE,
-  searchMethod = JS(
-    "function(rows, columnIds, filterValue) {
-    return rows.filter(function(row) {
-      var measure = String(row.values['measure_id']).toLowerCase();
-      var desc = String(row.values['description']).toLowerCase();
-      var search = filterValue.toLowerCase();
-      return measure.indexOf(search) >= 0 || desc.indexOf(search) >= 0;
-    });
-  }"
-  ),
-  defaultPageSize = nrow(metadata_monthly_ltc),
+  defaultPageSize = 10,
   columns = list(
     measure_id = colDef(
       name = "Measure ID and description",
@@ -61,7 +51,7 @@ reactable(
         )
       }
     ),
-    description = colDef(show = FALSE)
+    description = colDef(show = FALSE, searchable = TRUE)
   ),
   outlined = TRUE,
   striped = TRUE

--- a/vignettes/metadata-ods.Rmd
+++ b/vignettes/metadata-ods.Rmd
@@ -40,7 +40,7 @@ reactable(
   metadata_ods,
   searchable = TRUE,
   sortable = TRUE,
-  defaultPageSize = 20,
+  defaultPageSize = 10,
   columns = list(
     org_name = colDef(
       name = "NHS TT provider",
@@ -87,7 +87,6 @@ reactable(
       minWidth = 60
     )
   ),
-  pagination = FALSE,
   outlined = TRUE,
   striped = TRUE
 )


### PR DESCRIPTION
This was related to name changes of the datasets, now with the suffix `_period` (e.g., `_annual` or `_monthly`)